### PR TITLE
Refactor load account

### DIFF
--- a/src/store/accounts/actions.js
+++ b/src/store/accounts/actions.js
@@ -19,6 +19,10 @@ export const createNewAccount = () => (dispatch) => {
   );
 };
 
+export const loadAccount = (account) => (dispatch) => {
+  dispatch(addAccount(account));
+};
+
 const loadAccountFromFile = async () => {
   const [fileHandle] = await window.showOpenFilePicker();
   const file = await fileHandle.getFile();

--- a/src/views/Accounts/LoadButton.jsx
+++ b/src/views/Accounts/LoadButton.jsx
@@ -1,18 +1,44 @@
-import { Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
+import { useRef } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { actions } from '@/store/accounts';
 
 export default function LoadButton() {
   const dispatch = useDispatch();
+  const fileInputRef = useRef(null);
+
+  const handleChange = (event) => {
+    const file = event.target.files[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      const json = JSON.parse(reader.result);
+      dispatch(actions.loadAccount(json));
+    };
+    reader.readAsText(file);
+  };
+
+  const handleLoadAccountsClick = () => {
+    fileInputRef.current.click();
+  };
 
   return (
-    <Button
-      variant='contained'
-      color='primary'
-      onClick={() => dispatch(actions.loadAccountAsync())}
-    >
-      Load Account
-    </Button>
+    <Box>
+      <Button
+        variant='contained'
+        color='primary'
+        onClick={handleLoadAccountsClick}
+      >
+        Load Accounts
+      </Button>
+      <input
+        type='file'
+        id='fileInput'
+        ref={fileInputRef}
+        onChange={handleChange}
+        style={{ display: 'none' }}
+        multiple
+      />
+    </Box>
   );
 }


### PR DESCRIPTION
Closes #69 

# Changes

- Converted Load Account button to using the <input> tag
- Button uses ref to trigger input element click event